### PR TITLE
Bastischubert/fixup powernet

### DIFF
--- a/powercom/Makefile
+++ b/powercom/Makefile
@@ -21,8 +21,8 @@ XPPC-MIB:
 	@echo ">> Downloading XPPC-MIB"
 	@curl $(CURL_OPTS) -o XPPC-MIB "$(POWERCOM_URL)"
 	# Patch to replace RFC1213-MIB with SNMPv2-TC.
-	@sed -i.bak -z -E 's/(DisplayString[[:space:]\n]+FROM) RFC1213-MIB/\1 SNMPv2-TC/' XPPC-MIB
-	@rm XPPC-MIB.bak
+	@sed -i.bak -E 's/(DisplayString[[:space:]\n]+FROM) RFC1213-MIB/\1 SNMPv2-TC/' XPPC-MIB
+	@rm XPPC-MIB.bak XPPC-MIB.bak2
 
 .PHONY: clean
 clean:

--- a/powercom/Makefile
+++ b/powercom/Makefile
@@ -22,6 +22,8 @@ XPPC-MIB:
 	@curl $(CURL_OPTS) -o XPPC-MIB "$(POWERCOM_URL)"
 	# Patch to replace RFC1213-MIB with SNMPv2-TC.
 	@sed -i.bak -E 's/(DisplayString[[:space:]\n]+FROM) RFC1213-MIB/\1 SNMPv2-TC/' XPPC-MIB
+	# Patch to fix malformed mib.
+	@sed -i.bak2 -e 's/Normal(2}/normal(2) }/' -e 's/UPS Fault(/fault(/' XPPC-MIB
 	@rm XPPC-MIB.bak XPPC-MIB.bak2
 
 .PHONY: clean

--- a/powercom/XPPC-MIB
+++ b/powercom/XPPC-MIB
@@ -15,7 +15,7 @@ IMPORTS
         TRAP-TYPE
                 FROM RFC-1215
         DisplayString
-                FROM SNMPv2-TC
+                FROM RFC1213-MIB
         OBJECT-TYPE
                 FROM RFC-1212
         enterprises,
@@ -455,8 +455,8 @@ upsBaseBatteryLifeDays OBJECT-TYPE
 upsBaseUPSFault OBJECT-TYPE
         SYNTAX INTEGER {
                         unknown(0),
-                        UPS Fault(1),
-                        Normal(2}
+                        fault(1),
+                        normal(2) }
         ACCESS read-only
         STATUS mandatory
         DESCRIPTION


### PR DESCRIPTION
fix broken downloaded mib - syntax error, lowercase, no whitspaces
also fixed the sed command that would not run on on the sed that comes with MacOS